### PR TITLE
Use v3 of PR Labeler

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -7,6 +7,6 @@ jobs:
   pr-labeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: TimonVS/pr-labeler-action@master
+      - uses: TimonVS/pr-labeler-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hey, thanks for using PR Labeler! I noticed you were using the master version of PR Labeler. I've removed support for binding to the master version in [v3](https://github.com/TimonVS/pr-labeler-action/releases/tag/v3.0.0). I've updated the configuration to bind to v3 which will make the action work properly again.